### PR TITLE
Work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 Xmlresolver.iml
 dist
 out
+B
 xmlresolver.jar
+target

--- a/src/org/xmlresolver/CacheFlush.java
+++ b/src/org/xmlresolver/CacheFlush.java
@@ -50,7 +50,7 @@ public class CacheFlush {
 
     public void run(String dir) {
         ResourceCache cache = new ResourceCache(dir);
-        Document catalog = cache.catalog();
+        Element catalog = cache.catalog();
         Vector<String> expired = new Vector<String> ();
         Vector<String> uptodate = new Vector<String> ();
 
@@ -60,7 +60,7 @@ public class CacheFlush {
         }
 
         int count = 0;
-        Element entry = DOMUtils.getFirstElement(catalog.getDocumentElement());
+        Element entry = DOMUtils.getFirstElement(catalog);
         while (entry != null) {
             String uri = null;
             if ("uri".equals(entry.getLocalName())) {
@@ -76,7 +76,7 @@ public class CacheFlush {
         int okCount = 0;
         int expCount = 0;
         
-        entry = DOMUtils.getFirstElement(catalog.getDocumentElement());
+        entry = DOMUtils.getFirstElement(catalog);
         while (entry != null) {
             String uri = null;
             if ("uri".equals(entry.getLocalName())) {

--- a/src/org/xmlresolver/CacheInfo.java
+++ b/src/org/xmlresolver/CacheInfo.java
@@ -47,7 +47,7 @@ public class CacheInfo {
 
     public void run(String dir) {
         ResourceCache cache = new ResourceCache(dir);
-        Document catalog = cache.catalog();
+        Element catalog = cache.catalog();
         Vector<String> expired = new Vector<String> ();
         Vector<String> uptodate = new Vector<String> ();
 
@@ -57,7 +57,7 @@ public class CacheInfo {
         }
 
         int count = 0;
-        Element entry = DOMUtils.getFirstElement(catalog.getDocumentElement());
+        Element entry = DOMUtils.getFirstElement(catalog);
         while (entry != null) {
             String uri = null;
             if ("uri".equals(entry.getLocalName())) {
@@ -70,7 +70,7 @@ public class CacheInfo {
         
         System.out.println("Cache contains " + count + " entries.");
         
-        entry = DOMUtils.getFirstElement(catalog.getDocumentElement());
+        entry = DOMUtils.getFirstElement(catalog);
         while (entry != null) {
             if ("uri".equals(entry.getLocalName())) {
                 System.out.println("URI:    " + entry.getAttribute("name"));

--- a/src/org/xmlresolver/Catalog.java
+++ b/src/org/xmlresolver/Catalog.java
@@ -319,7 +319,7 @@ public class Catalog {
             logger.finer("  Looking in " + aDocRoot.getBaseURI());
             CatalogResult resolved = aFunction.apply(aDocRoot);
             if (resolved != null) {
-                logger.fine("  Found: " + resolved);
+                logger.finer("  Found: " + resolved);
                 return resolved;
             }
         }
@@ -349,7 +349,7 @@ public class Catalog {
     private CatalogResult lookupInDocsOnly(LookupFunction aFunction) {
       CatalogResult r1 = lookupInDocs(aFunction);
       if (r1 == null) {
-          logger.fine("  Not found");
+          logger.finer("  Not found");
       }
       return r1;
     }
@@ -358,7 +358,7 @@ public class Catalog {
       CatalogResult r1 = lookupInDocs(aFunction);
       CatalogResult r2 = r1 != null ? r1: lookupInCache(aFunction);
       if (r2 == null) {
-          logger.fine("  Not found");
+          logger.finer("  Not found");
       }
       return r2;
     }
@@ -505,7 +505,7 @@ public class Catalog {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public CatalogResult lookupPublic(String systemId, String publicId) {
-        logger.fine("lookupPublic(" + systemId + "," + publicId + ")");
+        logger.finer("lookupPublic(" + systemId + "," + publicId + ")");
         final ProcessedIds processedIds = processIds(systemId, publicId);
         return lookupInDocsOrCache(new LookupFunction() {
             public CatalogResult apply(Element docElem) {
@@ -608,7 +608,7 @@ public class Catalog {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public CatalogResult lookupSystem(String aSystemId) {
-        logger.fine("lookupSystem(" + aSystemId + ")");
+        logger.finer("lookupSystem(" + aSystemId + ")");
 
         final String systemId = URIUtils.normalizeURI(aSystemId);
 
@@ -709,7 +709,7 @@ public class Catalog {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public CatalogResult lookupDoctype(final String entityName, String systemId, String publicId) {
-        logger.fine("lookupDoctype(" + entityName + "," + publicId + "," + systemId + ")");
+        logger.finer("lookupDoctype(" + entityName + "," + publicId + "," + systemId + ")");
         final ProcessedIds processedIds = processIds(systemId, publicId);
         // Maybe lookupInDocsOrCache should be used here too.
         return lookupInDocsOnly(new LookupFunction() {
@@ -775,7 +775,7 @@ public class Catalog {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public CatalogResult lookupDocument() {
-        logger.fine("lookupDocument()");
+        logger.finer("lookupDocument()");
         return lookupInDocsOnly(new LookupFunction() {
             public CatalogResult apply(Element docElem) {
               return lookupDocument(docElem);
@@ -806,7 +806,7 @@ public class Catalog {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public CatalogResult lookupEntity(final String entityName, String systemId, String publicId) {
-        logger.fine("lookupEntity(" + entityName + "," + publicId + "," + systemId + ")");
+        logger.finer("lookupEntity(" + entityName + "," + publicId + "," + systemId + ")");
         final ProcessedIds processedIds = processIds(systemId, publicId);
         return lookupInDocsOnly(new LookupFunction() {
             public CatalogResult apply(Element docElem) {
@@ -876,7 +876,7 @@ public class Catalog {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public CatalogResult lookupNotation(final String notName, String systemId, String publicId) {
-        logger.fine("lookupNotation(" + notName + "," + publicId + "," + systemId + ")");
+        logger.finer("lookupNotation(" + notName + "," + publicId + "," + systemId + ")");
         final ProcessedIds processedIds = processIds(systemId, publicId);
         return lookupInDocsOnly(new LookupFunction() {
             public CatalogResult apply(Element docElem) {

--- a/src/org/xmlresolver/Catalog.java
+++ b/src/org/xmlresolver/Catalog.java
@@ -100,7 +100,7 @@ public class Catalog {
     private Configuration conf;
     
     private Vector<CatalogSource> catalogList = new Vector<CatalogSource>();
-    private Vector<Document> documentList = new Vector<Document>();
+    private Vector<Element> documentList = new Vector<Element>();
     private ResourceCache cache = null;
 
     /** Creates a catalog using properties read from the default property file.
@@ -197,26 +197,25 @@ public class Catalog {
       return conf.queryCacheSchemeURI(scheme);
     }
 
-    private synchronized Document loadCatalog(int index) {
+    private synchronized Element loadCatalog(int index) {
         if (index < documentList.size()) {
             return documentList.get(index);
         }
         
         CatalogSource catalog = catalogList.get(index);
 
-        Document doc = catalog.parse();
+        Element docRoot = catalog.parse();
         
         while (documentList.size() <= index) {
             documentList.add(null);
         }
-        documentList.set(index, doc);
+        documentList.set(index, docRoot);
 
         int offset = 1;
-        if (doc != null) {
-            Element root = doc.getDocumentElement();
+        if (docRoot != null) {
                         
-            if (catalogElement(root, "catalog")) {
-                Element child = DOMUtils.getFirstElement(root);
+            if (catalogElement(docRoot, "catalog")) {
+                Element child = DOMUtils.getFirstElement(docRoot);
                 while (child != null) {
                     if (catalogElement(child, "nextCatalog")) {
                         Element nextCat = (Element) child;
@@ -235,7 +234,7 @@ public class Catalog {
             }
         }
         
-        return doc;
+        return docRoot;
     }
 
     private boolean catalogElement(Node node, String localName) {
@@ -315,10 +314,10 @@ public class Catalog {
         return _lookupNamespaceURI(uri, nature, purpose);
     }
     
-    private static CatalogResult lookupInDoc(LookupFunction aFunction, Document aDoc) {
-        if (aDoc != null) {
-            logger.finer("  Looking in " + aDoc.getBaseURI());
-            CatalogResult resolved = aFunction.apply(aDoc.getDocumentElement());
+    private static CatalogResult lookupInDoc(LookupFunction aFunction, Element aDocRoot) {
+        if (aDocRoot != null) {
+            logger.finer("  Looking in " + aDocRoot.getBaseURI());
+            CatalogResult resolved = aFunction.apply(aDocRoot);
             if (resolved != null) {
                 logger.fine("  Found: " + resolved);
                 return resolved;
@@ -331,8 +330,8 @@ public class Catalog {
         int index = 0;
         while (index < catalogList.size()) {
             loadCatalog(index);
-            Document doc = documentList.get(index);
-            CatalogResult resolved = lookupInDoc(aFunction, doc);
+            Element docRoot = documentList.get(index);
+            CatalogResult resolved = lookupInDoc(aFunction, docRoot);
             if (resolved != null) return resolved;
             index++;
         }

--- a/src/org/xmlresolver/CatalogSource.java
+++ b/src/org/xmlresolver/CatalogSource.java
@@ -7,6 +7,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -16,74 +17,102 @@ import org.xml.sax.SAXException;
  * @author swachter
  */
 public abstract class CatalogSource<S> {
-  
+
   private static DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
   static {
     factory.setNamespaceAware(true);
   }
-  
   protected final S mySource;
 
   protected CatalogSource(S aSource) {
     mySource = aSource;
   }
+  
+  public abstract Element parse();
 
-  public Document parse() {
-    DocumentBuilder builder = null;
-    Document doc = null;
-    try {
-      builder = factory.newDocumentBuilder();
-      doc = doParse(builder);
-      return doc;
-    } catch (ParserConfigurationException pce) {
-      Catalog.logger.warning("Parser configuration exception attempting to load " + this);
+  //
+  //
+  //
+  
+  public abstract static class ParsingCatalogSource<S> extends CatalogSource<S> {
+
+    public ParsingCatalogSource(S aSource) {
+      super(aSource);
+    }
+
+    public Element parse() {
+      try {
+        DocumentBuilder builder = null;
+        Document doc = null;
+        builder = factory.newDocumentBuilder();
+        doc = doParse(builder);
+        return doc.getDocumentElement();
+      } catch (ParserConfigurationException pce) {
+        Catalog.logger.warning("Parser configuration exception attempting to load " + this);
+        return null;
+      } catch (FileNotFoundException fnfe) {
+        // ignore this one
+        Catalog.logger.finer("Catalog file not found: " + this);
+      } catch (IOException ex) {
+        Catalog.logger.warning("I/O exception reading " + this + ": " + ex.toString());
+      } catch (SAXException ex) {
+        Catalog.logger.warning("SAX exception reading " + this + ": " + ex.toString());
+      }
       return null;
-    } catch (FileNotFoundException fnfe) {
-      // ignore this one
-      Catalog.logger.finer("Catalog file not found: " + this);
-    } catch (IOException ex) {
-      Catalog.logger.warning("I/O exception reading " + this + ": " + ex.toString());
-    } catch (SAXException ex) {
-      Catalog.logger.warning("SAX exception reading " + this + ": " + ex.toString());
     }
-    return doc;
+
+    public String toString() {
+      return mySource.toString();
+    }
+
+    protected abstract Document doParse(DocumentBuilder aDocumentBuilder) throws SAXException, IOException;
   }
 
-  protected abstract Document doParse(DocumentBuilder aDocumentBuilder) throws SAXException, IOException;
+  public static class UriCatalogSource extends ParsingCatalogSource<String> {
 
-  public String toString() {
-    return mySource.toString();
+    public UriCatalogSource(String aSource) {
+      super(aSource);
+    }
+
+    @Override
+    protected Document doParse(DocumentBuilder aDocumentBuilder) throws SAXException, IOException {
+      return aDocumentBuilder.parse(mySource);
+    }
   }
 
-    public static class UriCatalogSource extends CatalogSource<String> {
-      public UriCatalogSource(String aSource) {
-        super(aSource);
-      }
-      @Override
-      protected Document doParse(DocumentBuilder aDocumentBuilder) throws SAXException, IOException {
-        return aDocumentBuilder.parse(mySource);
-      }
+  public static class InputSourceCatalogSource extends ParsingCatalogSource<InputSource> {
+
+    public InputSourceCatalogSource(InputSource aSource) {
+      super(aSource);
     }
-    
-    public static class InputSourceCatalogSource extends CatalogSource<InputSource> {
-      public InputSourceCatalogSource(InputSource aSource) {
-        super(aSource);
-      }
-      @Override
-      protected Document doParse(DocumentBuilder aDocumentBuilder) throws SAXException, IOException {
-        return aDocumentBuilder.parse(mySource);
-      }
+
+    @Override
+    protected Document doParse(DocumentBuilder aDocumentBuilder) throws SAXException, IOException {
+      return aDocumentBuilder.parse(mySource);
     }
-    
-    public static class InputStreamCatalogSource extends CatalogSource<InputStream> {
-      public InputStreamCatalogSource(InputStream aSource) {
-        super(aSource);
-      }
-      @Override
-      protected Document doParse(DocumentBuilder aDocumentBuilder) throws SAXException, IOException {
-        return aDocumentBuilder.parse(mySource);
-      }
+  }
+
+  public static class InputStreamCatalogSource extends ParsingCatalogSource<InputStream> {
+
+    public InputStreamCatalogSource(InputStream aSource) {
+      super(aSource);
     }
-    
+
+    @Override
+    protected Document doParse(DocumentBuilder aDocumentBuilder) throws SAXException, IOException {
+      return aDocumentBuilder.parse(mySource);
+    }
+  }
+  
+  public static class DomCatalogSource extends CatalogSource<Element> {
+    public DomCatalogSource(Element aSource) {
+      super(aSource);
+    }
+    @Override
+    public Element parse() {
+      return mySource;
+    }
+    public String toString() { return "DOM(baseUri:" + mySource.getBaseURI() + ")"; }
+  }
 }

--- a/src/org/xmlresolver/ResourceCache.java
+++ b/src/org/xmlresolver/ResourceCache.java
@@ -289,7 +289,7 @@ public class ResourceCache {
     }
 
     /** Returns an OASIS XML Catalog document for the resources in the cache. */
-    public synchronized Document catalog() {
+    public synchronized Element catalog() {
         if (!cacheDir.exists() || !cacheDir.isDirectory()) {
             return null;
         }
@@ -299,7 +299,7 @@ public class ResourceCache {
             cleanupCache();
         }
 
-        return cache;
+        return catalog;
     }
 
     private synchronized void cleanupCache() {

--- a/test/org/xmlresolver/ResourceCacheTest.java
+++ b/test/org/xmlresolver/ResourceCacheTest.java
@@ -42,7 +42,7 @@ public class ResourceCacheTest extends TestCase {
 
     public void testInit() {
         ResourceCache cache = new ResourceCache("catalogs/cache");
-        Document catalog = cache.catalog();
+        Element catalog = cache.catalog();
     }
     
     public void testAddURI() throws MalformedURLException, IOException {


### PR DESCRIPTION
- Refactored Catalog by removing redundant code
- Use document element node instead of the document node as a handle to the catalog information; this allows to easily register catalogs that are embedded in XML documents.
