### PR TITLE
Remove `xmlresolver.properties` from the distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ See also: https://xmlresolver.org/
 
 ## Release notes
 
+### 1.0.1, ?? March 2019
+
+* Removed the default `xmlresolver.properties` file that shipped with the XML Resolver jar file.
+  This fixes [issue 21](https://github.com/ndw/xmlresolver/issues/21) but introduces no change
+  in behavior because the default values in the absence of a property configuration file are all
+  the same as what was in that default properties file.
+
 ### 1.0.0, 2 March 2019
 
 * Let’s call it 1.0.0!

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ See also: https://xmlresolver.org/
 
 ## Release notes
 
-### 1.0.1, ?? March 2019
+### 1.0.1, 5 March 2019
 
-* Removed the default `xmlresolver.properties` file that shipped with the XML Resolver jar file.
+* Removed the default `xmlresolver.properties` file that shipped in the XML Resolver jar file.
   This fixes [issue 21](https://github.com/ndw/xmlresolver/issues/21) but introduces no change
   in behavior because the default values in the absence of a property configuration file are all
   the same as what was in that default properties file.

--- a/core/src/main/java/org/xmlresolver/Configuration.java
+++ b/core/src/main/java/org/xmlresolver/Configuration.java
@@ -16,6 +16,15 @@ import java.util.Vector;
  * @author swachter
  */
 public class Configuration {
+    private final Properties properties;
+    private final URL propertiesFileUri;
+
+    public Configuration(Properties properties, URL propertiesFileUri) {
+        Catalog.logger.debug("XMLResolver version " + BuildConfig.VERSION);
+        Catalog.logger.debug("Loading xmlresolver.properties: " + propertiesFileUri);
+        this.properties = properties;
+        this.propertiesFileUri = propertiesFileUri;
+    }
 
     private static boolean isTrue(String aString) {
         return "true".equalsIgnoreCase(aString) || "yes".equalsIgnoreCase(aString) || "1".equalsIgnoreCase(aString);
@@ -77,8 +86,6 @@ public class Configuration {
         Configuration config = null;
 
         if (propurl != null) {
-            Catalog.logger.debug("XMLResolver version " + BuildConfig.VERSION);
-            Catalog.logger.debug("Loading xmlresolver.properties: " + propurl);
             Properties properties = new Properties();
             try {
                 properties.load(propurl.openStream());
@@ -89,14 +96,6 @@ public class Configuration {
         }
 
         return config;
-    }
-
-    private final Properties properties;
-    private final URL propertiesFileUri;
-
-    public Configuration(Properties properties, URL propertiesFileUri) {
-        this.properties = properties;
-        this.propertiesFileUri = propertiesFileUri;
     }
 
     private String getProperty(String aPropertyName) {

--- a/core/src/main/resources/xmlresolver.properties
+++ b/core/src/main/resources/xmlresolver.properties
@@ -1,8 +1,0 @@
-# Default XML Resolver properties. Override this by putting
-# an "xmlresolver.properties" file in your classpath before
-# the XML resolver jar file.
-
-relative-catalogs=yes
-catalogs=./catalog.xml
-prefer=public
-allow-oasis-xml-catalog-pi=yes

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.0.0
+version=1.0.1a
 group=org.xmlresolver


### PR DESCRIPTION
Fix #21 

Removing the properties file has no effect on behavior because the default values used in the absence of a properties file are precisely the same as the values in the default properties file.
