### PR TITLE
Fix http runtime dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ configurations.all {
   }
 }
 
+configurations {
+  standaloneClasspath.extendsFrom(testImplementation)
+}
+
 dependencies {
   implementation (
     [group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.5'],
@@ -25,16 +29,9 @@ dependencies {
     [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25' ]
   )
 
-  runtimeOnly (
-    [group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.5'],
-    [group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.9'],
-    [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25' ]
-  )
-
   testImplementation (
     [group: 'junit', name: 'junit', version: '4.12'],
     [group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.1'],
-    [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.1'],
     [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.1']
   )
 }
@@ -45,6 +42,14 @@ if (!hasProperty("sonatypeUsername")) {
 
 if (!hasProperty("sonatypePassword")) {
   ext.sonatypePassword=""
+}
+
+def EXCP="${projectDir}/build/classes/java/main"
+configurations.standaloneClasspath.each { it ->
+  // Explicitly remove the http libraries
+  if (!it.toString().contains("http")) {
+    EXCP += ":" + it
+  }
 }
 
 buildConfig {
@@ -168,6 +173,17 @@ publishing {
       }
     }
   }
+}
+
+// Test that the resolver can function without the http client
+// libraries on the classpath. You don't get caching, obviously,
+// but you also don't get a runtime exception!
+task standaloneTest(type: Exec, dependsOn: ["compileJava"]) {
+  commandLine "java",
+    "-Dlog4j.configurationFile=/Users/ndw/java/log4j2-debug.xml",
+    "-cp", EXCP, "org.xmlresolver.apps.Parse",
+    "-c", "src/test/resources/catalog.xml",
+    "-s", "src/test/resources/doc.xml"
 }
 
 task deleteBuild() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 basename=xmlresolver
-resolverVersion=1.0.8
+resolverVersion=1.1.0
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/ResourceResolver.java
+++ b/src/main/java/org/xmlresolver/ResourceResolver.java
@@ -169,29 +169,34 @@ public class ResourceResolver {
         } else {
             return null;
         }
-    }    
-    
-    private Resource cacheStreamSystem(String resolved, String publicId) {
-        ResourceConnection conn = new ResourceConnection(resolved);
+    }
 
-        if (conn.getStatusCode() == 200) {
-            String absuriString = conn.getURI();
-            if (cache != null && catalog.cacheSchemeURI(getScheme(absuriString)) && cache.cacheURI(absuriString)) {
-                try {
-                    String localName = cache.addSystem(conn, publicId);
-                    File localFile = new File(localName);
-                    InputStream result = new FileInputStream(localFile);
-                    return new Resource(result, absuriString);
-                } catch (IOException ioe) {
-                    return null;
+    private Resource cacheStreamSystem(String resolved, String publicId) {
+        try {
+            ResourceConnection conn = new ResourceConnection(resolved);
+
+            if (conn.getStatusCode() == 200) {
+                String absuriString = conn.getURI();
+                if (cache != null && catalog.cacheSchemeURI(getScheme(absuriString)) && cache.cacheURI(absuriString)) {
+                    try {
+                        String localName = cache.addSystem(conn, publicId);
+                        File localFile = new File(localName);
+                        InputStream result = new FileInputStream(localFile);
+                        return new Resource(result, absuriString);
+                    } catch (IOException ioe) {
+                        return null;
+                    }
+                } else {
+                    return new Resource(conn.getStream(), absuriString);
                 }
-            } else {                        
-                return new Resource(conn.getStream(), absuriString);
             }
-        } else {
+        } catch (NoClassDefFoundError ncdfe) {
+            logger.debug("Apache http library classes apparently unavailable, not attempting to cache");
             return null;
         }
-    }    
+
+        return null;
+    }
 
     /** Resolve a URI. 
      *

--- a/src/test/resources/doc.xml
+++ b/src/test/resources/doc.xml
@@ -2,7 +2,7 @@
 <doc xmlns="http://example.org/ns/document"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://example.org/ns/document
-                         http://exampel.org/schema/doc.xsd">
+                         http://example.org/schema/doc.xsd">
 <title>Document Title</title>
 <p>This is some <emphasis>text</emphasis>.</p>
 </doc>


### PR DESCRIPTION
Fixed a bug in the resource resolver where it would throw an exception if the HTTP client libraries were unavailable. These libraries are required if you want to use the caching feature, but if they’re unavailable the resolver will still function correctly with the existing local catalogs.

Fixed a typo in the test file `doc.xml`. This doesn’t actually change any results.

Confirmed that all of the logging code dependencies are on the SLF4J API. SLF4J is a logging facade. You can use the XML Resolver libraries with whatever logging system you prefer, provided that you include at least one logging implementation. Close #34 
